### PR TITLE
remove Vue dependency and unused function

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,11 +1,3 @@
-import Vue from 'vue';
-
-const Observer = new Vue().$data.__ob__.constructor;
-
-export function makeNonreactive(obj) {
-  obj.__ob__ = new Observer({});
-}
-
 export const addDep = (FC, modules) => {
   if (FC) {
     if (


### PR DESCRIPTION
I noticed that the `vue-fusioncharts` dist files are very huge. It looks like it is including the `Vue` object unnecessarily. (probably accidental?). I saw that this also causing the component to print `You are running Vue in development mode...` every time, even in production environment.

Proposing to remove the import and the related unused function. 
 