### PR TITLE
RED-8974- vue-fusioncharts is logging developement-mode message while used in production build

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,11 +1,3 @@
-import Vue from 'vue';
-
-const Observer = new Vue().$data.__ob__.constructor;
-
-export function makeNonreactive(obj) {
-  obj.__ob__ = new Observer({});
-}
-
 export const addDep = (FC, modules) => {
   if (FC) {
     if (


### PR DESCRIPTION
Jira : https://fusioncharts.jira.com/browse/RED-8974
Description : vue-fusioncharts is logging development-mode message while used in production build
Fix : removed the VUE object dependency from util which was responsible for creating development mode messages
