### PR TITLE
RED-8974- vue-fusioncharts is logging developement-mode message while used in production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,8 @@
     "yards": "^0.1.4"
   },
   "dependencies": {
-    "underscore": "^1.9.1"
+    "mixin-deep": "^1.3.2",
+    "underscore": "^1.9.1",
+    "websocket-extensions": "^0.1.4"
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,11 +1,3 @@
-import Vue from 'vue';
-
-const Observer = new Vue().$data.__ob__.constructor;
-
-export function makeNonreactive(obj) {
-  obj.__ob__ = new Observer({});
-}
-
 export const addDep = (FC, modules) => {
   if (FC) {
     if (


### PR DESCRIPTION
Jira : https://fusioncharts.jira.com/browse/RED-8974
Description : vue-fusioncharts is logging development-mode message while used in production build
Fix : removed the VUE object dependency from util which was responsible for creating development mode messages